### PR TITLE
Create vanilla backbone models from bacon.js properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+spec/*.spec.js

--- a/dist/backbone.eventstreams.js
+++ b/dist/backbone.eventstreams.js
@@ -62,4 +62,18 @@
 
   _.extend(Backbone.View.prototype, Backbone.EventStream);
 
+  Backbone.BaconProperty = {
+    toModel: function() {
+      var handler, model;
+      model = new Backbone.Model(this.take(1));
+      handler = function(value) {
+        return model.set(value);
+      };
+      this.onValue(handler);
+      return model;
+    }
+  };
+
+  _.extend(Bacon.Property.prototype, Backbone.BaconProperty);
+
 }).call(this);

--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -17,6 +17,7 @@
   <script type="text/javascript" src="../dist/backbone.eventstreams.js"></script>
 
   <!-- include spec files here... -->
+  <script type="text/javascript" src="backbone.eventstreams.spec.js"></script>
 
   <script type="text/javascript">
     (function() {

--- a/spec/backbone.eventstreams.spec.coffee
+++ b/spec/backbone.eventstreams.spec.coffee
@@ -1,0 +1,18 @@
+describe 'Backbone.EventStream', ->
+
+    it 'can turn bacon.js properties to models', ->
+        username = Bacon.once("johndoe")
+        loggedIn = new Bacon.Bus
+        user     = Bacon.combineTemplate({ username: username, loggedIn: loggedIn.toProperty(false) })
+        model    = user.toModel()
+        stub     = jasmine.createSpy('stub')
+
+        model.on("change:loggedIn", stub)
+        expect(model.get("loggedIn")).toBe false
+        expect(stub).wasNotCalled()
+
+        loggedIn.push(true)
+        expect(stub).wasCalled()
+        expect(model.get("loggedIn")).toBe true
+
+        loggedIn.push()

--- a/src/backbone.eventstreams.coffee
+++ b/src/backbone.eventstreams.coffee
@@ -29,3 +29,14 @@ _.extend Backbone.Collection.prototype, Backbone.EventStream
 _.extend Backbone.Router.prototype,     Backbone.EventStream
 _.extend Backbone.History.prototype,    Backbone.EventStream
 _.extend Backbone.View.prototype,       Backbone.EventStream
+
+Backbone.BaconProperty =
+  toModel: ->
+    model = new Backbone.Model(this.take(1))
+    handler = (value) ->
+      model.set value
+    this.onValue(handler)
+    model
+      
+
+_.extend Bacon.Property.prototype,      Backbone.BaconProperty


### PR DESCRIPTION
Came across an idea: most of the time my backbone models are very plain (or at least close to that). What if you could do bacon.combineTemplate to get a property, and then just wrap that into a backbone model?

Combine this with e.g. Marionette and you get a very sleek several-bacon-streams-into-a-single-ui-view workflow...
